### PR TITLE
feat: rockstore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,6 +427,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.60.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -523,6 +542,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 
 [[package]]
+name = "bytecheck"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d11cac2c12b5adc6570dad2ee1b87eff4955dac476fe12d81e5fdd352e52406f"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13e576ebe98e605500b3c8041bb888e966653577172df6dd97398714eb30b9bf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -535,10 +575,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 
 [[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "ccm"
@@ -549,6 +603,15 @@ dependencies = [
  "aead 0.3.2",
  "cipher 0.2.5",
  "subtle",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -611,6 +674,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa2e27ae6ab525c3d369ded447057bca5438d86dc3a68f6faafb8269ba82ebf3"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -1510,6 +1584,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
 name = "group"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1989,6 +2069,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 
 [[package]]
+name = "jobserver"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2031,6 +2120,12 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
@@ -2124,6 +2219,16 @@ dependencies = [
  "libipld-core",
  "prost",
  "thiserror",
+]
+
+[[package]]
+name = "libloading"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+dependencies = [
+ "cfg-if",
+ "winapi",
 ]
 
 [[package]]
@@ -2505,6 +2610,21 @@ dependencies = [
  "parking_lot 0.12.1",
  "thiserror",
  "yamux",
+]
+
+[[package]]
+name = "librocksdb-sys"
+version = "0.8.0+7.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "611804e4666a25136fcc5f8cf425ab4d26c7f74ea245ffe92ea23b85b6420b5d"
+dependencies = [
+ "bindgen",
+ "bzip2-sys",
+ "cc",
+ "glob",
+ "libc",
+ "libz-sys",
+ "zstd-sys",
 ]
 
 [[package]]
@@ -3169,6 +3289,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
 name = "pem"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3355,15 +3481,22 @@ dependencies = [
  "ahash 0.8.2",
  "anyhow",
  "async-trait",
+ "bytecheck",
  "bytes",
  "cid",
  "clap",
  "colog",
+ "dirs-next",
  "futures",
  "iroh-bitswap",
  "iroh-car",
+ "libipld",
  "libp2p",
  "log",
+ "rkyv",
+ "rocksdb",
+ "smallvec",
+ "tempfile",
  "tokio",
 ]
 
@@ -3515,6 +3648,26 @@ checksum = "747761bc3dc48f9a34553bf65605cf6cb6288ba219f3450b4275dbd81539551a"
 dependencies = [
  "bytes",
  "prost",
+]
+
+[[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3736,6 +3889,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rend"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79af64b4b6362ffba04eef3a4e10829718a4896dac19daa741851c86781edf95"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3811,12 +3973,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "rkyv"
+version = "0.7.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cec2b3485b07d96ddfd3134767b8a447b45ea4eb91448d0a35180ec0ffd5ed15"
+dependencies = [
+ "bytecheck",
+ "hashbrown",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eaedadc88b53e36dd32d940ed21ae4d850d5916f2581526921f553a72ac34c4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "rlimit"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7278a1ec8bfd4a4e07515c589f5ff7b309a373f987393aef44813d9dcf87aa3"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "rocksdb"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e9562ea1d70c0cc63a34a22d977753b50cca91cc6b6527750463bd5dd8697bc"
+dependencies = [
+ "libc",
+ "librocksdb-sys",
 ]
 
 [[package]]
@@ -4014,6 +4211,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
 name = "sec1"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4142,6 +4345,12 @@ checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "signal-hook-registry"
@@ -5564,4 +5773,14 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.4+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fa202f2ef00074143e219d15b62ffc317d17cc33909feac471c044087cad7b0"
+dependencies = [
+ "cc",
+ "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,10 @@ ahash = "0.8.0"
 bytes = "1.1.0"
 log = "0.4.17"
 colog = "1.1.0"
+rocksdb = "0.19.0"
+smallvec = { version = "1.10.0", features = ["write"] }
+rkyv = { version = "0.7.37", features = ["validation"] }
+bytecheck = "0.6.7"
+libipld = "0.15.0"
+dirs-next = "2.0.0"
+tempfile = "3.3.0"

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,0 +1,688 @@
+use ahash::AHashSet;
+use anyhow::{anyhow, bail, Context, Result};
+use async_trait::async_trait;
+use bytecheck::CheckBytes;
+use bytes::{Bytes, BytesMut};
+use cid::multihash::Multihash;
+use cid::Cid;
+use iroh_bitswap::{Block, Store as BitswapStore};
+use rkyv::{with::AsBox, Archive, Deserialize, Serialize};
+/// Ipld Store implementation based on Iroh's RockDB config
+/// without the RPC.
+use rocksdb::{
+    BlockBasedOptions, Cache, ColumnFamily, DBPinnableSlice, Direction, IteratorMode, Options,
+    WriteBatch, DB as RocksDb,
+};
+use smallvec::SmallVec;
+use std::path::PathBuf;
+use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
+use std::thread::available_parallelism;
+use tokio::task;
+
+/// Creates the default rocksdb options
+/// based on Iroh's implementation.
+fn default_options() -> (Options, Cache) {
+    let mut opts = Options::default();
+    opts.set_write_buffer_size(512 * 1024 * 1024);
+    opts.optimize_for_point_lookup(64 * 1024 * 1024);
+    let par = (available_parallelism().map(|s| s.get()).unwrap_or(2) / 4).min(2);
+    opts.increase_parallelism(par as _);
+    opts.set_compression_type(rocksdb::DBCompressionType::Lz4);
+    opts.set_bottommost_compression_type(rocksdb::DBCompressionType::Zstd);
+    opts.set_blob_compression_type(rocksdb::DBCompressionType::Lz4);
+    opts.set_bytes_per_sync(1_048_576);
+    opts.set_blob_file_size(512 * 1024 * 1024);
+
+    let cache = Cache::new_lru_cache(128 * 1024 * 1024).unwrap();
+    let mut bopts = BlockBasedOptions::default();
+    // all our data is longer lived, so ribbon filters make sense
+    bopts.set_ribbon_filter(10.0);
+    bopts.set_block_cache(&cache);
+    bopts.set_block_size(6 * 1024);
+    bopts.set_cache_index_and_filter_blocks(true);
+    bopts.set_pin_l0_filter_and_index_blocks_in_cache(true);
+    opts.set_block_based_table_factory(&bopts);
+
+    (opts, cache)
+}
+
+fn default_blob_opts() -> Options {
+    let mut opts = Options::default();
+    opts.set_enable_blob_files(true);
+    opts.set_min_blob_size(5 * 1024);
+
+    opts
+}
+
+/// The key used in CF_ID_V0
+///
+/// The multihash followed by the be encoded code. This allows both looking up an id by multihash and code (aka Cid),
+/// and looking up all codes and ids for a multihash, for the rare case that there are mulitple cids with the same
+/// multihash but different codes.
+fn id_key(cid: &Cid) -> SmallVec<[u8; 64]> {
+    let mut key = SmallVec::new();
+    cid.hash().write(&mut key).unwrap();
+    key.extend_from_slice(&cid.codec().to_be_bytes());
+    key
+}
+
+#[derive(Clone)]
+pub struct RockStore {
+    inner: Arc<InnerStore>,
+}
+
+impl std::fmt::Debug for RockStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RockStore").finish()
+    }
+}
+
+struct InnerStore {
+    content: RocksDb,
+    next_id: RwLock<u64>,
+    _cache: Cache,
+}
+
+#[async_trait]
+impl BitswapStore for RockStore {
+    async fn get_size(&self, cid: &Cid) -> anyhow::Result<usize> {
+        self.get_size(cid)?.ok_or_else(|| anyhow!("not found"))
+    }
+
+    async fn get(&self, cid: &Cid) -> anyhow::Result<Block> {
+        let slice = self
+            .read_store()?
+            .get(cid)?
+            .ok_or_else(|| anyhow!("not found"))?;
+        let bytes = BytesMut::from(&slice[..]).freeze();
+        Ok(Block::new(bytes, *cid))
+    }
+
+    async fn has(&self, cid: &Cid) -> anyhow::Result<bool> {
+        self.has(cid)
+    }
+}
+
+impl RockStore {
+    /// Creates a new database.
+    pub async fn create(path: PathBuf) -> Result<Self> {
+        let (mut options, cache) = default_options();
+        options.create_if_missing(true);
+
+        let db = task::spawn_blocking(move || -> Result<_> {
+            let mut db = RocksDb::open(&options, path)?;
+            {
+                let opts = default_blob_opts();
+                db.create_cf(CF_BLOBS_V0, &opts)?;
+            }
+            {
+                let opts = Options::default();
+                db.create_cf(CF_METADATA_V0, &opts)?;
+            }
+            {
+                let opts = Options::default();
+                db.create_cf(CF_GRAPH_V0, &opts)?;
+            }
+            {
+                let opts = Options::default();
+                db.create_cf(CF_ID_V0, &opts)?;
+            }
+
+            Ok(db)
+        })
+        .await??;
+
+        Ok(RockStore {
+            inner: Arc::new(InnerStore {
+                content: db,
+                next_id: 1.into(),
+                _cache: cache,
+            }),
+        })
+    }
+
+    pub async fn open(path: PathBuf) -> Result<Self> {
+        let (mut options, cache) = default_options();
+        options.create_if_missing(false);
+
+        let (db, next_id) = task::spawn_blocking(move || -> Result<_> {
+            let db = RocksDb::open_cf(
+                &options,
+                path,
+                [CF_BLOBS_V0, CF_METADATA_V0, CF_GRAPH_V0, CF_ID_V0],
+            )?;
+
+            // read last inserted id
+            let next_id = {
+                let cf_meta = db
+                    .cf_handle(CF_METADATA_V0)
+                    .ok_or_else(|| anyhow!("missing column family: metadata"))?;
+
+                let mut iter = db.full_iterator_cf(&cf_meta, IteratorMode::End);
+                let last_id = iter
+                    .next()
+                    .and_then(|r| r.ok())
+                    .and_then(|(key, _)| key[..8].try_into().ok())
+                    .map(u64::from_be_bytes)
+                    .unwrap_or_default();
+
+                last_id + 1
+            };
+
+            Ok((db, next_id))
+        })
+        .await??;
+
+        Ok(RockStore {
+            inner: Arc::new(InnerStore {
+                content: db,
+                next_id: next_id.into(),
+                _cache: cache,
+            }),
+        })
+    }
+
+    pub fn put<T: AsRef<[u8]>, L>(&self, cid: Cid, blob: T, links: L) -> Result<()>
+    where
+        L: IntoIterator<Item = Cid>,
+    {
+        self.write_store()?.put(cid, blob, links)
+    }
+
+    pub fn put_many(&self, blocks: impl IntoIterator<Item = (Cid, Bytes, Vec<Cid>)>) -> Result<()> {
+        self.write_store()?.put_many(blocks)
+    }
+
+    pub fn get_blob_by_hash(&self, hash: &Multihash) -> Result<Option<DBPinnableSlice<'_>>> {
+        self.read_store()?.get_blob_by_hash(hash)
+    }
+
+    pub fn has_blob_for_hash(&self, hash: &Multihash) -> Result<bool> {
+        self.read_store()?.has_blob_for_hash(hash)
+    }
+
+    pub fn get(&self, cid: &Cid) -> Result<Option<DBPinnableSlice<'_>>> {
+        self.read_store()?.get(cid)
+    }
+
+    pub fn get_size(&self, cid: &Cid) -> Result<Option<usize>> {
+        self.read_store()?.get_size(cid)
+    }
+
+    pub fn has(&self, cid: &Cid) -> Result<bool> {
+        self.read_store()?.has(cid)
+    }
+
+    pub fn get_links(&self, cid: &Cid) -> Result<Option<Vec<Cid>>> {
+        self.read_store()?.get_links(cid)
+    }
+
+    pub fn consistency_check(&self) -> Result<Vec<String>> {
+        self.read_store()?.consistency_check()
+    }
+
+    fn write_store(&self) -> Result<WriteStore> {
+        let db = &self.inner.content;
+        Ok(WriteStore {
+            db,
+            cf: ColumnFamilies::new(db)?,
+            next_id: self.inner.next_id.write().unwrap(),
+        })
+    }
+
+    fn read_store(&self) -> Result<ReadStore> {
+        let db = &self.inner.content;
+        Ok(ReadStore {
+            db,
+            cf: ColumnFamilies::new(db)?,
+            _next_id: self.inner.next_id.read().unwrap(),
+        })
+    }
+}
+
+/// Groups all write operations.
+///
+/// Not Send, so must be used from a single thread.
+///
+/// All write interacion with the database is done through this struct.
+struct WriteStore<'a> {
+    db: &'a RocksDb,
+    cf: ColumnFamilies<'a>,
+    next_id: RwLockWriteGuard<'a, u64>,
+}
+
+/// Groups all read operations.
+///
+/// Not Send, so must be used from a single thread.
+///
+/// All read interacion with the database is done through this struct.
+struct ReadStore<'a> {
+    db: &'a RocksDb,
+    cf: ColumnFamilies<'a>,
+    _next_id: RwLockReadGuard<'a, u64>,
+}
+
+struct ColumnFamilies<'a> {
+    id: &'a ColumnFamily,
+    metadata: &'a ColumnFamily,
+    graph: &'a ColumnFamily,
+    blobs: &'a ColumnFamily,
+}
+
+/// Struct used to iterate over all the ids for a multihash
+struct CodeAndId {
+    // the ipld code of the id
+    #[allow(dead_code)]
+    code: u64,
+    // the id for the cid, used in most other column families
+    id: u64,
+}
+
+impl<'a> ColumnFamilies<'a> {
+    fn new(db: &'a RocksDb) -> anyhow::Result<Self> {
+        Ok(Self {
+            id: db
+                .cf_handle(CF_ID_V0)
+                .context("missing column family: id")?,
+            metadata: db
+                .cf_handle(CF_METADATA_V0)
+                .context("missing column family: metadata")?,
+            graph: db
+                .cf_handle(CF_GRAPH_V0)
+                .context("missing column family: graph")?,
+            blobs: db
+                .cf_handle(CF_BLOBS_V0)
+                .context("missing column family: blobs")?,
+        })
+    }
+}
+
+impl<'a> WriteStore<'a> {
+    fn put<T: AsRef<[u8]>, L>(&mut self, cid: Cid, blob: T, links: L) -> Result<()>
+    where
+        L: IntoIterator<Item = Cid>,
+    {
+        if self.has(&cid)? {
+            return Ok(());
+        }
+
+        let id = self.next_id();
+
+        let id_bytes = id.to_be_bytes();
+
+        // guranteed that the key does not exists, so we want to store it
+
+        let metadata = MetadataV0 {
+            codec: cid.codec(),
+            multihash: cid.hash().to_bytes(),
+        };
+        let metadata_bytes = rkyv::to_bytes::<_, 1024>(&metadata)?; // TODO: is this the right amount of scratch space?
+        let id_key = id_key(&cid);
+
+        let children = self.ensure_id_many(links.into_iter())?;
+
+        let graph = GraphV0 { children };
+        let graph_bytes = rkyv::to_bytes::<_, 1024>(&graph)?; // TODO: is this the right amount of scratch space?
+        let mut batch = WriteBatch::default();
+        batch.put_cf(self.cf.id, id_key, id_bytes);
+        batch.put_cf(self.cf.blobs, id_bytes, blob);
+        batch.put_cf(self.cf.metadata, id_bytes, metadata_bytes);
+        batch.put_cf(self.cf.graph, id_bytes, graph_bytes);
+        self.db.write(batch)?;
+
+        Ok(())
+    }
+
+    fn put_many(&mut self, blocks: impl IntoIterator<Item = (Cid, Bytes, Vec<Cid>)>) -> Result<()> {
+        let mut batch = WriteBatch::default();
+        let mut cid_tracker: AHashSet<Cid> = AHashSet::default();
+        for (cid, blob, links) in blocks.into_iter() {
+            if cid_tracker.contains(&cid) || self.has(&cid)? {
+                continue;
+            }
+
+            cid_tracker.insert(cid);
+
+            let id = self.next_id();
+
+            let id_bytes = id.to_be_bytes();
+
+            // guranteed that the key does not exists, so we want to store it
+
+            let metadata = MetadataV0 {
+                codec: cid.codec(),
+                multihash: cid.hash().to_bytes(),
+            };
+            let metadata_bytes = rkyv::to_bytes::<_, 1024>(&metadata)?; // TODO: is this the right amount of scratch space?
+            let id_key = id_key(&cid);
+
+            let children = self.ensure_id_many(links.into_iter())?;
+
+            let graph = GraphV0 { children };
+            let graph_bytes = rkyv::to_bytes::<_, 1024>(&graph)?; // TODO: is this the right amount of scratch space?
+
+            batch.put_cf(self.cf.id, id_key, id_bytes);
+            batch.put_cf(self.cf.blobs, id_bytes, blob);
+            batch.put_cf(self.cf.metadata, id_bytes, metadata_bytes);
+            batch.put_cf(self.cf.graph, id_bytes, graph_bytes);
+        }
+
+        self.db.write(batch)?;
+
+        Ok(())
+    }
+
+    /// Takes a list of cids and gives them ids, which are both stored and then returned.
+    fn ensure_id_many<I>(&mut self, cids: I) -> Result<Vec<u64>>
+    where
+        I: IntoIterator<Item = Cid>,
+    {
+        let mut ids = Vec::new();
+        let mut batch = WriteBatch::default();
+        for cid in cids {
+            let id_key = id_key(&cid);
+            let id = if let Some(id) = self.db.get_pinned_cf(self.cf.id, &id_key)? {
+                u64::from_be_bytes(id.as_ref().try_into()?)
+            } else {
+                let id = self.next_id();
+                let id_bytes = id.to_be_bytes();
+
+                let metadata = MetadataV0 {
+                    codec: cid.codec(),
+                    multihash: cid.hash().to_bytes(),
+                };
+                let metadata_bytes = rkyv::to_bytes::<_, 1024>(&metadata)?; // TODO: is this the right amount of scratch space?
+                batch.put_cf(&self.cf.id, id_key, id_bytes);
+                batch.put_cf(&self.cf.metadata, id_bytes, metadata_bytes);
+                id
+            };
+            ids.push(id);
+        }
+        self.db.write(batch)?;
+
+        Ok(ids)
+    }
+
+    fn next_id(&mut self) -> u64 {
+        let id = *self.next_id;
+        if let Some(next_id) = self.next_id.checked_add(1) {
+            *self.next_id = next_id;
+        } else {
+            panic!("this store is full");
+        }
+        id
+    }
+
+    fn get_id(&self, cid: &Cid) -> Result<Option<u64>> {
+        let id_key = id_key(cid);
+        let maybe_id_bytes = self.db.get_pinned_cf(self.cf.id, id_key)?;
+        match maybe_id_bytes {
+            Some(bytes) => {
+                let arr = bytes[..8].try_into().map_err(|e| anyhow!("{:?}", e))?;
+                Ok(Some(u64::from_be_bytes(arr)))
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn has(&self, cid: &Cid) -> Result<bool> {
+        match self.get_id(cid)? {
+            Some(id) => {
+                let exists = self
+                    .db
+                    .get_pinned_cf(self.cf.blobs, id.to_be_bytes())?
+                    .is_some();
+                Ok(exists)
+            }
+            None => Ok(false),
+        }
+    }
+}
+
+impl<'a> ReadStore<'a> {
+    fn get(&self, cid: &Cid) -> Result<Option<DBPinnableSlice<'a>>> {
+        let res = match self.get_id(cid)? {
+            Some(id) => {
+                let maybe_blob = self.get_by_id(id)?;
+                Ok(maybe_blob)
+            }
+            None => Ok(None),
+        };
+        res
+    }
+
+    fn get_size(&self, cid: &Cid) -> Result<Option<usize>> {
+        match self.get_id(cid)? {
+            Some(id) => {
+                let maybe_size = self.get_size_by_id(id)?;
+                Ok(maybe_size)
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn has(&self, cid: &Cid) -> Result<bool> {
+        match self.get_id(cid)? {
+            Some(id) => {
+                let exists = self
+                    .db
+                    .get_pinned_cf(self.cf.blobs, id.to_be_bytes())?
+                    .is_some();
+                Ok(exists)
+            }
+            None => Ok(false),
+        }
+    }
+
+    fn get_links(&self, cid: &Cid) -> Result<Option<Vec<Cid>>> {
+        let res = match self.get_id(cid)? {
+            Some(id) => {
+                let maybe_links = self.get_links_by_id(id)?;
+                Ok(maybe_links)
+            }
+            None => Ok(None),
+        };
+        res
+    }
+
+    fn get_id(&self, cid: &Cid) -> Result<Option<u64>> {
+        let id_key = id_key(cid);
+        let maybe_id_bytes = self.db.get_pinned_cf(self.cf.id, id_key)?;
+        match maybe_id_bytes {
+            Some(bytes) => {
+                let arr = bytes[..8].try_into().map_err(|e| anyhow!("{:?}", e))?;
+                Ok(Some(u64::from_be_bytes(arr)))
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn get_ids_for_hash(
+        &self,
+        hash: &Multihash,
+    ) -> Result<impl Iterator<Item = Result<CodeAndId>> + 'a> {
+        let hash = hash.to_bytes();
+        let iter = self
+            .db
+            .iterator_cf(self.cf.id, IteratorMode::From(&hash, Direction::Forward));
+        let hash_len = hash.len();
+        Ok(iter
+            .take_while(move |elem| {
+                if let Ok((k, _)) = elem {
+                    k.len() == hash_len + 8 && k.starts_with(&hash)
+                } else {
+                    // we don't want to swallow errors. An error is not the same as no result!
+                    true
+                }
+            })
+            .map(move |elem| {
+                let (k, v) = elem?;
+                let code = u64::from_be_bytes(k[hash_len..].try_into()?);
+                let id = u64::from_be_bytes(v[..8].try_into()?);
+                Ok(CodeAndId { code, id })
+            }))
+    }
+
+    fn get_blob_by_hash(&self, hash: &Multihash) -> Result<Option<DBPinnableSlice<'a>>> {
+        for elem in self.get_ids_for_hash(hash)? {
+            let id = elem?.id;
+            let id_bytes = id.to_be_bytes();
+            if let Some(blob) = self.db.get_pinned_cf(self.cf.blobs, id_bytes)? {
+                return Ok(Some(blob));
+            }
+        }
+        Ok(None)
+    }
+
+    fn has_blob_for_hash(&self, hash: &Multihash) -> Result<bool> {
+        for elem in self.get_ids_for_hash(hash)? {
+            let id = elem?.id;
+            let id_bytes = id.to_be_bytes();
+            if let Some(_blob) = self.db.get_pinned_cf(self.cf.blobs, id_bytes)? {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    fn get_by_id(&self, id: u64) -> Result<Option<DBPinnableSlice<'a>>> {
+        let maybe_blob = self.db.get_pinned_cf(self.cf.blobs, id.to_be_bytes())?;
+
+        Ok(maybe_blob)
+    }
+
+    fn get_size_by_id(&self, id: u64) -> Result<Option<usize>> {
+        let maybe_blob = self.db.get_pinned_cf(self.cf.blobs, id.to_be_bytes())?;
+        let maybe_size = maybe_blob.map(|b| b.len());
+        Ok(maybe_size)
+    }
+
+    fn get_links_by_id(&self, id: u64) -> Result<Option<Vec<Cid>>> {
+        let id_bytes = id.to_be_bytes();
+        // FIXME: can't use pinned because otherwise this can trigger alignment issues :/
+        let cf = &self.cf;
+        match self.db.get_cf(cf.graph, id_bytes)? {
+            Some(links_id) => {
+                let graph = rkyv::check_archived_root::<GraphV0>(&links_id)
+                    .map_err(|e| anyhow!("{:?}", e))?;
+                let keys = graph
+                    .children
+                    .iter()
+                    .map(|id| (&cf.metadata, id.to_be_bytes()));
+                let meta = self.db.multi_get_cf(keys);
+                let mut links = Vec::with_capacity(meta.len());
+                for (i, meta) in meta.into_iter().enumerate() {
+                    match meta? {
+                        Some(meta) => {
+                            let meta = rkyv::check_archived_root::<MetadataV0>(&meta)
+                                .map_err(|e| anyhow!("{:?}", e))?;
+                            let multihash = cid::multihash::Multihash::from_bytes(&meta.multihash)?;
+                            let c = cid::Cid::new_v1(meta.codec, multihash);
+                            links.push(c);
+                        }
+                        None => {
+                            bail!("invalid link: {}", graph.children[i]);
+                        }
+                    }
+                }
+                Ok(Some(links))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Perform an internal consistency check on the store, and return all internal errors found.
+    fn consistency_check(&self) -> anyhow::Result<Vec<String>> {
+        let mut res = Vec::new();
+        let cf = &self.cf;
+        let n_meta = self
+            .db
+            .iterator_cf(&cf.metadata, IteratorMode::Start)
+            .count();
+        let n_id = self.db.iterator_cf(&cf.id, IteratorMode::Start).count();
+        if n_meta != n_id {
+            res.push(format!(
+                "non bijective mapping between cid and id. Metadata and id cfs have different lengths: {} != {}",
+                n_meta, n_id
+            ));
+        }
+        Ok(res)
+    }
+}
+
+/// Column family to store actual data.
+/// - Maps id (u64) to bytes
+const CF_BLOBS_V0: &str = "blobs-v0";
+/// Column family that stores metdata about a given blob.
+/// - indexed by id (u64)
+const CF_METADATA_V0: &str = "metadata-v0";
+/// Column familty that stores the graph for a blob
+/// - indexed by id (u64)
+const CF_GRAPH_V0: &str = "graph-v0";
+/// Column family that stores the mapping (multihash, code) to id.
+///
+/// By storing multihash first we can search for ids either by cid = (multihash, code) or by multihash.
+const CF_ID_V0: &str = "id-v0";
+
+// This wrapper type serializes the contained value out-of-line so that newer
+// versions can be viewed as the older version.
+#[derive(Debug, Archive, Deserialize, Serialize)]
+#[repr(transparent)]
+#[archive_attr(repr(transparent), derive(CheckBytes))]
+struct Versioned<T>(#[with(AsBox)] T);
+
+#[derive(Debug, Archive, Deserialize, Serialize)]
+#[repr(C)]
+#[archive_attr(repr(C), derive(CheckBytes))]
+struct MetadataV0 {
+    /// The codec of the original CID.
+    codec: u64,
+    multihash: Vec<u8>,
+}
+
+#[derive(Debug, Archive, Deserialize, Serialize)]
+#[repr(C)]
+#[archive_attr(repr(C), derive(CheckBytes))]
+struct GraphV0 {
+    children: Vec<u64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use cid::multihash::{Code, MultihashDigest};
+    const RAW: u64 = 0x55;
+
+    #[tokio::test]
+    async fn test_basics() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let store = RockStore::create(dir.path().into()).await.unwrap();
+
+        let mut values = Vec::new();
+
+        for i in 0..100 {
+            let data = vec![i as u8; i * 16];
+            let hash = Code::Sha2_256.digest(&data);
+            let c = cid::Cid::new_v1(RAW, hash);
+
+            let link_hash = Code::Sha2_256.digest(&[(i + 1) as u8; 64]);
+            let link = cid::Cid::new_v1(RAW, link_hash);
+
+            let links = [link];
+
+            store.put(c, &data, links).unwrap();
+            values.push((c, data, links));
+        }
+
+        for (_i, (c, expected_data, expected_links)) in values.iter().enumerate() {
+            assert!(store.has(c).unwrap());
+            let data = store.get(c).unwrap().unwrap();
+            assert_eq!(expected_data, &data[..]);
+
+            let links = store.get_links(c).unwrap().unwrap();
+            assert_eq!(expected_links, &links[..]);
+        }
+    }
+}


### PR DESCRIPTION
This replaces the memory store with a persistent blockstore based on Iroh's RocksDB implementation without the RPC.
Also adds a `--tempstore` flag to use a temp directory as the store path so it is destroyed after shutting down. Useful for testing.