### PR TITLE
 feat: custom protocol for parallel transfers via work stealing 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3683,6 +3683,9 @@ dependencies = [
  "smallvec",
  "tempfile",
  "tokio",
+ "tork",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anyhow"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -573,6 +579,9 @@ name = "bytes"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bzip2-sys"
@@ -583,6 +592,21 @@ dependencies = [
  "cc",
  "libc",
  "pkg-config",
+]
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cbor4ii"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebce4be718fce03915a0a6220eaca81becdab6485d6ad57d483ed6ff76def7b7"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -646,6 +670,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "cid"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ed9c8b2d17acb8110c46f1da5bf4a696d745e1474a16db0cd2b49cd0249bf2"
+dependencies = [
+ "core2",
+ "multibase",
+ "multihash 0.16.3",
+ "serde",
+ "serde_bytes",
+ "unsigned-varint",
+]
+
+[[package]]
 name = "cid"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -655,6 +720,7 @@ dependencies = [
  "multibase",
  "multihash 0.17.0",
  "serde",
+ "serde_bytes",
  "unsigned-varint",
 ]
 
@@ -689,13 +755,25 @@ dependencies = [
 
 [[package]]
 name = "clap"
+version = "3.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
+dependencies = [
+ "bitflags",
+ "clap_lex 0.2.4",
+ "indexmap",
+ "textwrap",
+]
+
+[[package]]
+name = "clap"
 version = "4.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d63b9e9c07271b9957ad22c173bae2a4d9a81127680962039296abcd2f8251d"
 dependencies = [
  "bitflags",
  "clap_derive",
- "clap_lex",
+ "clap_lex 0.3.0",
  "is-terminal",
  "once_cell",
  "strsim",
@@ -713,6 +791,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -857,6 +944,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
+dependencies = [
+ "anes",
+ "atty",
+ "cast",
+ "ciborium",
+ "clap 3.2.23",
+ "criterion-plot",
+ "futures",
+ "itertools",
+ "lazy_static",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "tokio",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -949,6 +1074,15 @@ checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
  "generic-array",
  "subtle",
+]
+
+[[package]]
+name = "cs_serde_bytes"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc673ddabf48214550526b068dc28065a75f05e21e452880095247c635b1d91"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1088,6 +1222,12 @@ dependencies = [
  "crossbeam-queue",
  "tokio",
 ]
+
+[[package]]
+name = "deque"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a694dae478589798d752c7125542f8a5ae8b6e59476172baf2eed67357bdfa27"
 
 [[package]]
 name = "der"
@@ -1620,6 +1760,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1956,7 +2102,7 @@ dependencies = [
  "async-trait",
  "asynchronous-codec",
  "bytes",
- "cid",
+ "cid 0.9.0",
  "deadqueue",
  "derivative",
  "futures",
@@ -1987,7 +2133,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6bf2d0427b65cacedd75d3d0d4db15d8be5630f6b918260d50aad315cd32370"
 dependencies = [
- "cid",
+ "cid 0.9.0",
  "futures",
  "integer-encoding",
  "libipld",
@@ -2026,7 +2172,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3fa64e0d5e312eb3947213a798e990792f3e61022e77b47dd2b217860c10ff7"
 dependencies = [
  "anyhow",
- "cid",
+ "cid 0.9.0",
  "config",
  "ctrlc",
  "dirs-next",
@@ -2182,10 +2328,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7a704ba3b25dee9e7a2361fae2c7c19defae2a92e69ae96ffb203996705cd7c"
 dependencies = [
  "anyhow",
- "cid",
+ "cid 0.9.0",
  "core2",
  "multibase",
  "multihash 0.17.0",
+ "serde",
  "thiserror",
 ]
 
@@ -2818,6 +2965,8 @@ dependencies = [
  "core2",
  "digest 0.10.6",
  "multihash-derive",
+ "serde",
+ "serde-big-array",
  "sha2 0.10.6",
  "unsigned-varint",
 ]
@@ -2834,6 +2983,8 @@ dependencies = [
  "core2",
  "digest 0.10.6",
  "multihash-derive",
+ "serde",
+ "serde-big-array",
  "sha2 0.10.6",
  "sha3",
  "unsigned-varint",
@@ -3091,6 +3242,12 @@ name = "once_cell"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+
+[[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opaque-debug"
@@ -3427,6 +3584,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
+name = "plotters"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2538b639e642295546c50fcd545198c9d64ee2a38620a628724a3b266d5fbf97"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "193228616381fecdc1224c62e96946dfbc73ff4384fba576e052ff8c1bea8142"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a81d2759aae1dae668f783c308bc5c8ebd191ff4184aaa1b37f65a6ae5a56f"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "polling"
 version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3483,8 +3668,8 @@ dependencies = [
  "async-trait",
  "bytecheck",
  "bytes",
- "cid",
- "clap",
+ "cid 0.9.0",
+ "clap 4.0.29",
  "colog",
  "dirs-next",
  "futures",
@@ -4173,6 +4358,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4246,6 +4440,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-big-array"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd31f59f6fe2b0c055371bb2f16d7f0aa7d8881676c04a55b1596d1a17cd10a4"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfc50e8183eeeb6178dcb167ae34a8051d63535023ae38b5d8d12beae193d37b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4257,6 +4469,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_ipld_dagcbor"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e23de7a4a18dff77ab9531f279a882500b8cf3549fde044d4e10481b411f1e"
+dependencies = [
+ "cbor4ii",
+ "cid 0.8.6",
+ "scopeguard",
+ "serde",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4265,6 +4489,38 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fe39d9fbb0ebf5eb2c7cb7e2a47e4f462fad1379f1166b8ae49ad9eae89a7ca"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_tuple"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f025b91216f15a2a32aa39669329a475733590a015835d1783549a56d09427"
+dependencies = [
+ "serde",
+ "serde_tuple_macros",
+]
+
+[[package]]
+name = "serde_tuple_macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4076151d1a2b688e25aaf236997933c66e18b870d0369f8b248b8ab2be630d7e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -4589,6 +4845,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
+
+[[package]]
 name = "thiserror"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4808,6 +5070,34 @@ dependencies = [
  "prost-build",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tork"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-channel",
+ "async-stream",
+ "async-trait",
+ "asynchronous-codec",
+ "bytes",
+ "criterion",
+ "cs_serde_bytes",
+ "deque",
+ "futures",
+ "libipld",
+ "libp2p",
+ "rand 0.8.5",
+ "serde",
+ "serde_ipld_dagcbor",
+ "serde_repr",
+ "serde_tuple",
+ "smallvec",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -5142,6 +5432,17 @@ name = "waker-fn"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+
+[[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ bytecheck = "0.6.7"
 libipld = "0.15.0"
 dirs-next = "2.0.0"
 tempfile = "3.3.0"
+tork = { version = "0.1", path = "./tork" }
+tracing = "0.1.34"
+tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,8 @@ bytecheck = "0.6.7"
 libipld = "0.15.0"
 dirs-next = "2.0.0"
 tempfile = "3.3.0"
+
+[workspace]
+members = [
+  "tork",
+]

--- a/src/behaviour.rs
+++ b/src/behaviour.rs
@@ -1,4 +1,5 @@
 use crate::store::RockStore;
+use clap::{Parser, ValueEnum};
 use iroh_bitswap::{Bitswap, BitswapEvent};
 use libp2p::relay::v2::{
     client::Client as RelayClient, client::Event as RelayClientEvent, relay::Event as RelayEvent,
@@ -34,26 +35,11 @@ pub struct PopTartBehaviour {
 #[derive(Clone, Debug)]
 pub struct ProtocolParserError(String);
 
-#[derive(Default, Copy, Clone, Debug)]
+#[derive(Default, Copy, Clone, Debug, ValueEnum)]
 pub enum TransferProtocol {
     #[default]
     Tork,
     Bitswap,
-}
-impl FromStr for TransferProtocol {
-    type Err = ProtocolParserError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s == "bitswap" {
-            Ok(TransferProtocol::Bitswap)
-        } else if s == "tork" {
-            Ok(TransferProtocol::Tork)
-        } else {
-            Err(ProtocolParserError(
-                "incorrectly formatted protocol string".to_string(),
-            ))
-        }
-    }
 }
 
 #[derive(Default, Clone, Copy)]

--- a/src/behaviour.rs
+++ b/src/behaviour.rs
@@ -14,6 +14,7 @@ use libp2p::{
     relay,
     swarm::{behaviour::toggle::Toggle, NetworkBehaviour},
 };
+use std::str::FromStr;
 use tork::Tork;
 
 pub const PROTOCOL_VERSION: &str = "poptart/0.1.0";
@@ -30,15 +31,36 @@ pub struct PopTartBehaviour {
     pub bitswap: Toggle<Bitswap<RockStore>>,
 }
 
-enum TransferProtocol {
+#[derive(Clone, Debug)]
+pub struct ProtocolParserError(String);
+
+#[derive(Default, Copy, Clone, Debug)]
+pub enum TransferProtocol {
+    #[default]
     Tork,
     Bitswap,
 }
+impl FromStr for TransferProtocol {
+    type Err = ProtocolParserError;
 
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s == "bitswap" {
+            Ok(TransferProtocol::Bitswap)
+        } else if s == "tork" {
+            Ok(TransferProtocol::Tork)
+        } else {
+            Err(ProtocolParserError(
+                "incorrectly formatted protocol string".to_string(),
+            ))
+        }
+    }
+}
+
+#[derive(Default, Clone, Copy)]
 pub struct PopTartConfig {
-    is_relay: bool,
-    is_relay_client: bool,
-    transfer_protocol: TransferProtocol,
+    pub is_relay: bool,
+    pub is_relay_client: bool,
+    pub transfer_protocol: TransferProtocol,
 }
 
 unsafe impl Send for PopTartBehaviour {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use ahash::HashMap;
 use bytes::Bytes;
 use cid::Cid;
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use futures::{
     channel::{mpsc, oneshot},
     prelude::*,
@@ -67,8 +67,16 @@ async fn main() -> Result<(), anyhow::Error> {
     info!("starting poptart 🍭 ...");
     let opt = Opt::parse();
     let mut config = PopTartConfig::default();
-    config.transfer_protocol = TransferProtocol::from_str(&opt.transfer_protocol)
-        .expect("failed to parse protocol string");
+
+    match opt.transfer_protocol {
+        TransferProtocol::Bitswap => {
+            info!("running bitswap");
+        }
+        TransferProtocol::Tork => {
+            info!("running tork");
+        }
+    }
+
     if let CliArgument::Relay { .. } = opt.argument {
         info!("you are a hole-punching 🧃 relay. thank you for your service 🫡.");
         config.is_relay = true;
@@ -169,8 +177,8 @@ struct Opt {
     port: u16,
     #[clap(long)]
     relay: Option<Multiaddr>,
-    #[clap(long)]
-    transfer_protocol: String,
+    #[clap(long, value_enum)]
+    transfer_protocol: TransferProtocol,
     #[clap(subcommand)]
     argument: CliArgument,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ use libp2p::{
 use log::{debug, info, warn};
 use smallvec::SmallVec;
 use std::collections::BTreeSet;
+use std::env;
 use std::path::PathBuf;
 use std::time::Instant;
 use std::{env, vec};
@@ -63,6 +64,7 @@ fn poptart_data_root() -> anyhow::Result<PathBuf> {
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     colog::init();
+
     info!("starting poptart 🍭 ...");
     let opt = Opt::parse();
     let is_relay_client = if let CliArgument::Relay { .. } = opt.argument {
@@ -148,6 +150,7 @@ async fn main() -> Result<(), anyhow::Error> {
                 client.dial(peer).await?;
             }
             client.resolve(root).await?;
+            info!("resolved content");
         }
         CliArgument::Relay { port } => {
             client
@@ -354,19 +357,13 @@ impl EventLoop {
                 } = e
                 {
                     info!("peer told us our public address: {:?}", observed_addr);
-                    self.swarm
-                        .behaviour()
-                        .bitswap
-                        .on_identify(&peer_id, &protocols);
                     self.dial_requests
                         .remove(&peer_id)
                         .and_then(|sender| sender.send(Ok(())).ok());
                 }
             }
-            Event::Bitswap(e) => {
-                debug!("bitswap event: {:?}", e);
-                let _ = self.event_sender.send(Event::Bitswap(e));
-            }
+            Event::TorkEvent => {}
+            Event::Bitswap(_) => {}
         }
     }
 
@@ -409,38 +406,64 @@ impl EventLoop {
                 let behaviour = self.swarm.behaviour();
                 let store = self.store.clone();
 
-                let client = behaviour.bitswap.client().clone();
+                if let Some(bitswap) = behaviour.bitswap {
+                    let client = bitswap.client().clone();
+                    tokio::task::spawn(async move {
+                        let start = Instant::now();
 
-                tokio::task::spawn(async move {
-                    let start = Instant::now();
+                        let session = client.new_session().await;
 
-                    let session = client.new_session().await;
+                        let mut stack: SmallVec<[vec::IntoIter<Cid>; 8]> = SmallVec::new();
+                        stack.push(vec![root].into_iter());
 
-                    let mut stack: SmallVec<[vec::IntoIter<Cid>; 8]> = SmallVec::new();
-                    stack.push(vec![root].into_iter());
+                        while !stack.is_empty() {
+                            let next = stack.last_mut().expect("stack should be non-empty").next();
 
-                    while !stack.is_empty() {
-                        let next = stack.last_mut().expect("stack should be non-empty").next();
-
-                        match next {
-                            None => {
-                                stack.pop();
-                            }
-                            Some(cid) => {
-                                if let Ok(blk) = session.get_block(&cid).await {
-                                    if let Ok(links) = parse_links(blk.cid(), blk.data()) {
-                                        stack.push(links.clone().into_iter());
-                                        let _ = store.put(cid, blk.data(), links);
-                                    }
-                                };
+                            match next {
+                                None => {
+                                    stack.pop();
+                                }
+                                Some(cid) => {
+                                    if let Ok(blk) = session.get_block(&cid).await {
+                                        if let Ok(links) = parse_links(blk.cid(), blk.data()) {
+                                            stack.push(links.clone().into_iter());
+                                            let _ = store.put(cid, blk.data(), links);
+                                        }
+                                    };
+                                }
                             }
                         }
-                    }
-                    info!("completed transfer in {}ms", start.elapsed().as_millis());
+                        info!("completed transfer in {}ms", start.elapsed().as_millis());
 
-                    let _ = session.stop().await;
-                    let _ = sender.send(Ok(()));
-                });
+                        let _ = session.stop().await;
+                        let _ = sender.send(Ok(()));
+                    });
+                };
+
+                if let Some(tork) = behaviour.tork {
+                    let session = match behaviour.tork.new_session() {
+                        Ok(session) => session,
+                        Err(err) => {
+                            sender.send(Err(err)).ok();
+                            return;
+                        }
+                    };
+
+                    tokio::task::spawn(async move {
+                        let start = Instant::now();
+
+                        let stream = session.resolve_all(root).await;
+
+                        if let Err(err) = stream.try_collect::<Vec<_>>().await {
+                            sender.send(Err(err)).ok();
+                        } else {
+                            sender.send(Ok(())).ok();
+                        }
+                        info!("completed transfer in {}ms", start.elapsed().as_millis());
+
+                        session.stop();
+                    });
+                }
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -363,6 +363,9 @@ impl EventLoop {
                 } = e
                 {
                     info!("peer told us our public address: {:?}", observed_addr);
+                    if let Some(bitswap) = self.swarm.behaviour().bitswap.as_ref() {
+                        bitswap.on_identify(&peer_id, &protocols);
+                    }
                     self.dial_requests
                         .remove(&peer_id)
                         .and_then(|sender| sender.send(Ok(())).ok());

--- a/tork/Cargo.toml
+++ b/tork/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "tork"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1.0"
+async-trait = "0.1.57"
+async-channel = "1.7.1"
+async-stream = "0.3.3"
+deque = "0.3.2"
+serde = { version = "1.0", features = ["derive"] }
+serde_tuple = "0.5"
+serde_repr = "0.1"
+serde_ipld_dagcbor = "0.2.2"
+serde_bytes = { package = "cs_serde_bytes", version = "0.12" }
+libipld = { version = "0.15", features = ["serde-codec"] }
+libp2p = { version = "0.50", default-features = false }
+futures = "0.3.21"
+asynchronous-codec = "0.6.1"
+unsigned-varint = { version = "0.7.0", features = ["asynchronous_codec"] }
+tokio = { version = "1", features = ["sync"] }
+bytes = { version = "1.1.0", features = ["serde"] }
+smallvec = "1.9.0"
+tracing = "0.1.34"
+rand = "0.8.5"
+
+[dev-dependencies]
+criterion = {version = "0.4.0", features = ["async_tokio"]}
+libp2p = { version = "0.50", features = ["noise", "tcp", "yamux", "tokio"], default-features = false }
+tokio = { version = "1", features = ["macros", "net", "rt", "rt-multi-thread"] }
+tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
+
+[[bench]]
+name = "transfers"
+harness = false
+

--- a/tork/benches/transfers.rs
+++ b/tork/benches/transfers.rs
@@ -1,0 +1,133 @@
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use futures::prelude::*;
+use libipld::{ipld, Ipld};
+use libp2p::{
+    swarm::{Swarm, SwarmEvent},
+    Multiaddr,
+};
+use rand::prelude::*;
+use tokio::{runtime::Runtime, sync::mpsc};
+use tork::{create_block, encode_ipld, mk_transport, Store, TestStore, Tork};
+
+pub fn transfers_benchmark(c: &mut Criterion) {
+    static MB: usize = 1024 * 1024;
+
+    let mut group = c.benchmark_group("transfer_random_bytes");
+
+    for size in [MB].iter() {
+        group.throughput(Throughput::Bytes(*size as u64));
+        group.bench_with_input(
+            BenchmarkId::new("file_size", size),
+            size,
+            move |b, &size| {
+                const NP: usize = 4;
+                let executor = Runtime::new().unwrap();
+
+                let mut data = vec![0u8; size];
+                rand::thread_rng().fill_bytes(&mut data);
+
+                const CHUNK_SIZE: usize = 250 * 1024;
+
+                let store = TestStore::default();
+                let chunks = data.chunks(CHUNK_SIZE);
+
+                let links: Vec<Ipld> = chunks
+                    .map(|chunk| {
+                        // encoding as raw
+                        let (cid, _, _) = create_block(chunk.to_vec(), 0x55);
+                        store.put(cid, chunk, vec![]).ok();
+                        let link = ipld!({
+                            "Hash": cid,
+                            "Tsize": CHUNK_SIZE,
+                        });
+                        link
+                    })
+                    .collect();
+
+                let root_node = ipld!({
+                    "Links": links,
+                });
+
+                let buf = encode_ipld(0x71, &root_node);
+                let (root, bytes, _) = create_block(buf, 0x71);
+
+                store.put(root, bytes, vec![]).unwrap();
+
+                let (client, root) = executor.block_on(async {
+                    let (tx, mut rx) = mpsc::channel::<Multiaddr>(1);
+
+                    for _ in 0..NP {
+                        let (peer_id, trans) = mk_transport();
+                        let t = Tork::new(peer_id, store.clone());
+                        let mut provider = Swarm::with_tokio_executor(trans, t, peer_id);
+
+                        Swarm::listen_on(&mut provider, "/ip4/127.0.0.1/tcp/0".parse().unwrap())
+                            .unwrap();
+
+                        let sender = tx.clone();
+                        tokio::task::spawn(async move {
+                            while provider.next().now_or_never().is_some() {}
+                            let listeners: Vec<_> = Swarm::listeners(&provider).collect();
+                            for l in listeners {
+                                sender.send(l.clone()).await.unwrap();
+                            }
+
+                            loop {
+                                let _ev = provider.next().await;
+                            }
+                        });
+                    }
+
+                    let (peer_id, trans) = mk_transport();
+                    let t = Tork::new(peer_id, TestStore::default());
+                    let mut client_swarm = Swarm::with_tokio_executor(trans, t, peer_id);
+
+                    let client = client_swarm.behaviour().clone();
+
+                    for _ in 0..NP {
+                        let addr = rx.recv().await.unwrap();
+                        Swarm::dial(&mut client_swarm, addr).unwrap();
+                    }
+
+                    let mut conns = 0;
+
+                    loop {
+                        match client_swarm.next().await {
+                            Some(SwarmEvent::ConnectionEstablished { peer_id, .. }) => {
+                                conns += 1;
+                                if conns == NP {
+                                    break;
+                                }
+                            }
+                            _ => (),
+                        }
+                    }
+
+                    tokio::task::spawn(async move {
+                        loop {
+                            let _ev = client_swarm.next().await;
+                        }
+                    });
+
+                    (client, root)
+                });
+
+                b.to_async(&executor).iter(|| {
+                    let client = client.clone();
+                    async move {
+                        let session = client.new_session().unwrap();
+                        let content = session.resolve_all(root).await;
+
+                        let res = content.try_collect::<Vec<Ipld>>().await.unwrap();
+                        black_box(res)
+                    }
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, transfers_benchmark);
+criterion_main!(benches);

--- a/tork/src/lib.rs
+++ b/tork/src/lib.rs
@@ -332,7 +332,7 @@ impl ConnectionHandler for TorkHandler {
                             self.substream = Some(SubstreamState::WaitingOutput(substream));
                             return Poll::Ready(ConnectionHandlerEvent::Custom(message));
                         }
-                        Poll::Ready(Some(Err(error))) => {
+                        Poll::Ready(Some(Err(_))) => {
                             // More serious errors, close this side of the stream. If the
                             // peer is still around, they will re-establish their connection
                             self.substream = Some(SubstreamState::Closing(substream));

--- a/tork/src/lib.rs
+++ b/tork/src/lib.rs
@@ -1,0 +1,812 @@
+use anyhow::Result;
+use async_stream::try_stream;
+use asynchronous_codec::Framed;
+use futures::prelude::*;
+use futures::stream::FuturesUnordered;
+use libipld::codec::Codec;
+use libipld::codec_impl::IpldCodec;
+use libipld::{Cid, Ipld};
+use libp2p::core::{
+    connection::{ConnectedPoint, ConnectionId},
+    InboundUpgrade, OutboundUpgrade,
+};
+use libp2p::swarm::{
+    ConnectionHandler, ConnectionHandlerEvent, ConnectionHandlerUpgrErr, IntoConnectionHandler,
+    KeepAlive, NegotiatedSubstream, NetworkBehaviour, NetworkBehaviourAction, NotifyHandler,
+    PollParameters, SubstreamProtocol,
+};
+use libp2p::{Multiaddr, PeerId};
+use smallvec::SmallVec;
+use std::time::{Duration, Instant};
+use std::{
+    collections::{BTreeSet, HashMap},
+    io,
+    pin::Pin,
+    sync::{Arc, Mutex},
+    task::{Context, Poll},
+};
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+use tracing::{info, warn};
+
+mod prefix;
+mod protocol;
+
+use self::prefix::Prefix;
+pub use self::protocol::{tests::*, Store};
+use self::protocol::{Block, Message, TorkCodec, TorkProtocol};
+
+type ResponseSender = oneshot::Sender<Result<Message>>;
+
+type NetworkSender = async_channel::Sender<NetEvent>;
+
+#[derive(Debug)]
+pub enum NetEvent {
+    SendMessage {
+        peer: PeerId,
+        message: Message,
+        connection_id: ConnectionId,
+    },
+    SendRequest {
+        peer: PeerId,
+        message: Message,
+        connection_id: ConnectionId,
+        response: ResponseSender,
+    },
+}
+
+enum ConnState {
+    Connected(ConnectionId),
+    Disconnected,
+}
+
+#[derive(Debug, Clone)]
+pub struct Tork<S: Store> {
+    store: S,
+    self_id: PeerId,
+    conns: Arc<Mutex<HashMap<PeerId, ConnectionId>>>,
+    network_receiver: async_channel::Receiver<NetEvent>,
+    network_sender: NetworkSender,
+}
+
+type BlockSender = oneshot::Sender<Result<(Ipld, Vec<Cid>)>>;
+
+pub struct Task {
+    cid: Cid,
+    result: BlockSender,
+}
+
+#[derive(Debug)]
+pub struct Session<S: Store> {
+    store: S,
+    links: deque::Worker<Task>,
+    _workers: Arc<Vec<JoinHandle<()>>>,
+}
+
+impl<S: Store> Session<S> {
+    pub fn new<'a, P>(store: S, net: NetworkSender, providers: P) -> Self
+    where
+        P: Iterator<Item = (&'a PeerId, &'a ConnectionId)>,
+    {
+        let (w, s) = deque::new::<Task>();
+        let mut workers = Vec::new();
+        for (p, c) in providers {
+            let network_sender = net.clone();
+            let peer = *p;
+            let conn_id = *c;
+            let stealer = s.clone();
+            let store = store.clone();
+
+            // TODO: workers should keep track of peer connectivity, stats etc.
+            workers.push(tokio::task::spawn(async move {
+                loop {
+                    match stealer.steal() {
+                        deque::Data(task) => {
+                            let (s, r) = oneshot::channel();
+                            let _ = network_sender
+                                .send(NetEvent::SendRequest {
+                                    peer,
+                                    message: task.cid.into(),
+                                    connection_id: conn_id,
+                                    response: s,
+                                })
+                                .await;
+
+                            match r.await {
+                                Ok(Ok(res)) => {
+                                    let result = res
+                                        .response
+                                        .as_ref()
+                                        .and_then(|res| res.blocks.iter().next())
+                                        .ok_or_else(|| anyhow::format_err!("bad response message"))
+                                        .and_then(|blk| {
+                                            let cid = Prefix::new_from_bytes(&blk.prefix)?
+                                                .to_cid(&blk.data)?;
+                                            let codec = IpldCodec::try_from(cid.codec())?;
+                                            let node: Ipld = codec.decode(&blk.data)?;
+
+                                            let mut linkset = BTreeSet::new();
+                                            node.references(&mut linkset);
+                                            let links = linkset.into_iter().collect::<Vec<Cid>>();
+
+                                            store.put(cid, &blk.data, links.clone())?;
+                                            Ok((node, links))
+                                        });
+                                    if let Err(err) = task.result.send(result) {
+                                        warn!("task result sender: {:?}", err);
+                                    }
+                                }
+                                Ok(Err(other)) => {
+                                    warn!("send:{}: failed: {:?}", peer, other);
+                                }
+                                _ => {}
+                            };
+                        }
+                        deque::Empty => {
+                            tokio::task::yield_now().await;
+                        }
+                        deque::Abort => break,
+                    }
+                }
+            }));
+        }
+        Session {
+            store,
+            links: w,
+            _workers: Arc::new(workers),
+        }
+    }
+
+    pub async fn resolve_all(&self, root: Cid) -> impl Stream<Item = Result<Ipld>> + '_ {
+        let mut jobs = FuturesUnordered::new();
+        jobs.push(self.load_link(root));
+
+        try_stream! {
+
+            while let Some(Ok((node, links))) = jobs.next().await {
+
+                for l in links.into_iter() {
+                    jobs.push(self.load_link(l));
+                }
+
+                yield node;
+            }
+        }
+    }
+
+    pub async fn load_link(&self, cid: Cid) -> Result<(Ipld, Vec<Cid>)> {
+        let (s, r) = oneshot::channel();
+        self.links.push(Task { cid, result: s });
+        match r.await {
+            Ok(res) => res,
+            _ => Err(anyhow::format_err!("sender was dropped")),
+        }
+    }
+}
+
+impl<S: Store> Tork<S> {
+    pub fn new(self_id: PeerId, store: S) -> Self {
+        let (network_sender, network_receiver) = async_channel::bounded(1024);
+        Tork {
+            store,
+            self_id,
+            conns: Default::default(),
+            network_sender,
+            network_receiver,
+        }
+    }
+
+    pub fn new_session(&self) -> Result<Session<S>> {
+        let conns = self.conns.lock().unwrap();
+        if conns.len() == 0 {
+            return Err(anyhow::format_err!("no connected providers"));
+        }
+
+        Ok(Session::new(
+            self.store.clone(),
+            self.network_sender.clone(),
+            conns.iter(),
+        ))
+    }
+
+    // fn get_conn_id(&self, peer: &PeerId) -> Option<ConnectionId> {
+    //     self.conns.lock().unwrap().get(peer).copied()
+    // }
+
+    fn set_conn_state(&self, peer: &PeerId, new_state: ConnState) {
+        let peers = &mut *self.conns.lock().unwrap();
+        let peer = *peer;
+        match peers.entry(peer) {
+            std::collections::hash_map::Entry::Occupied(mut entry) => match new_state {
+                ConnState::Connected(id) => {
+                    *entry.get_mut() = id;
+                }
+                ConnState::Disconnected => {
+                    entry.remove();
+                }
+            },
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                if let ConnState::Connected(id) = new_state {
+                    entry.insert(id);
+                }
+            }
+        }
+    }
+}
+
+impl<S: Store> NetworkBehaviour for Tork<S> {
+    type ConnectionHandler = TorkHandler;
+    type OutEvent = ();
+
+    fn new_handler(&mut self) -> Self::ConnectionHandler {
+        TorkHandler::new()
+    }
+
+    fn addresses_of_peer(&mut self, _peer_id: &PeerId) -> Vec<Multiaddr> {
+        Default::default()
+    }
+
+    fn inject_connection_established(
+        &mut self,
+        peer_id: &PeerId,
+        connection: &ConnectionId,
+        _endpoint: &ConnectedPoint,
+        _failed_addresses: Option<&Vec<Multiaddr>>,
+        _other_established: usize,
+    ) {
+        self.set_conn_state(peer_id, ConnState::Connected(*connection));
+    }
+
+    fn inject_connection_closed(
+        &mut self,
+        peer_id: &PeerId,
+        _conn: &ConnectionId,
+        _endpoint: &ConnectedPoint,
+        _handler: <Self::ConnectionHandler as IntoConnectionHandler>::Handler,
+        _remaining_established: usize,
+    ) {
+        // TODO: handle multiple connection if that happens?
+        // not sure why a peer would need to keep multiple connections open with the same peer...
+        self.set_conn_state(peer_id, ConnState::Disconnected)
+    }
+
+    fn inject_event(&mut self, peer: PeerId, connection_id: ConnectionId, event: Message) {
+        if let Some(req) = event.request {
+            info!("{:} received a request", self.self_id);
+            tokio::task::spawn({
+                let store = self.store.clone();
+                let sender = self.network_sender.clone();
+                async move {
+                    if let Ok(bytes) = store.get(&req.root) {
+                        let blk = Block::new(req.root, bytes);
+                        let msg = Message::complete_response(vec![blk]);
+
+                        let _ = sender
+                            .send(NetEvent::SendMessage {
+                                peer,
+                                message: msg,
+                                connection_id,
+                            })
+                            .await;
+                    }
+                }
+            });
+        }
+    }
+
+    fn poll(
+        &mut self,
+        cx: &mut Context,
+        _: &mut impl PollParameters,
+    ) -> Poll<NetworkBehaviourAction<Self::OutEvent, Self::ConnectionHandler>> {
+        match Pin::new(&mut self.network_receiver).poll_next(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(None) => Poll::Pending,
+            Poll::Ready(Some(ev)) => match ev {
+                NetEvent::SendMessage {
+                    peer,
+                    message,
+                    connection_id,
+                } => {
+                    return Poll::Ready(NetworkBehaviourAction::NotifyHandler {
+                        peer_id: peer,
+                        handler: NotifyHandler::One(connection_id),
+                        event: HandlerInEvent::Response(message),
+                    });
+                }
+                NetEvent::SendRequest {
+                    peer,
+                    message,
+                    connection_id,
+                    response,
+                } => {
+                    return Poll::Ready(NetworkBehaviourAction::NotifyHandler {
+                        peer_id: peer,
+                        handler: NotifyHandler::One(connection_id),
+                        event: HandlerInEvent::Request(message, response),
+                    });
+                }
+            },
+        }
+    }
+}
+
+enum SubstreamState {
+    /// Waiting for a message from the remote. The idle state for an inbound substream.
+    WaitingInput(Framed<NegotiatedSubstream, TorkCodec>),
+    /// Waiting for the user to send a message. The idle state for an outbound substream.
+    WaitingOutput(Framed<NegotiatedSubstream, TorkCodec>),
+    /// Waiting to send a message to the remote with a future response.
+    PendingSend(Framed<NegotiatedSubstream, TorkCodec>, Message),
+    PendingSendWithResponse(
+        Framed<NegotiatedSubstream, TorkCodec>,
+        (Message, ResponseSender),
+    ),
+    /// Waiting to flush the substream so that the data arrives to the remote.
+    PendingFlush(Framed<NegotiatedSubstream, TorkCodec>),
+    PendingFlushWithResponse(Framed<NegotiatedSubstream, TorkCodec>, ResponseSender),
+    /// Waiting to read the response from the remote
+    PendingResponse(Framed<NegotiatedSubstream, TorkCodec>, ResponseSender),
+    /// The substream is being closed.
+    Closing(Framed<NegotiatedSubstream, TorkCodec>),
+    /// An error occurred during processing.
+    Poisoned,
+}
+// time in sec
+const INITIAL_KEEP_ALIVE: u64 = 30;
+
+pub struct TorkHandler {
+    /// Upgrade configuration for the bitswap protocol.
+    listen_protocol: SubstreamProtocol<TorkProtocol, ()>,
+    /// The single long-lived substream.
+    substream: Option<SubstreamState>,
+    send_queue: SmallVec<[HandlerInEvent; 16]>,
+    outbound_substream_establishing: bool,
+    keep_alive: KeepAlive,
+    /// The amount of time we allow idle connections before disconnecting.
+    idle_timeout: Duration,
+}
+
+impl TorkHandler {
+    fn new() -> Self {
+        TorkHandler {
+            listen_protocol: SubstreamProtocol::new(TorkProtocol(), ()),
+            substream: None,
+            send_queue: SmallVec::new(),
+            outbound_substream_establishing: false,
+            keep_alive: KeepAlive::Until(Instant::now() + Duration::from_secs(INITIAL_KEEP_ALIVE)),
+            idle_timeout: Duration::from_secs(30),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum HandlerInEvent {
+    Request(Message, ResponseSender),
+    Response(Message),
+}
+
+impl ConnectionHandler for TorkHandler {
+    type InEvent = HandlerInEvent;
+    type OutEvent = Message;
+    type Error = io::Error;
+    type InboundOpenInfo = ();
+    type InboundProtocol = TorkProtocol;
+    type OutboundOpenInfo = (Message, ResponseSender);
+    type OutboundProtocol = TorkProtocol;
+
+    fn listen_protocol(&self) -> SubstreamProtocol<Self::InboundProtocol, Self::InboundOpenInfo> {
+        self.listen_protocol.clone()
+    }
+
+    fn inject_fully_negotiated_inbound(
+        &mut self,
+        protocol: <Self::InboundProtocol as InboundUpgrade<NegotiatedSubstream>>::Output,
+        _info: Self::InboundOpenInfo,
+    ) {
+        self.substream = Some(SubstreamState::WaitingInput(protocol));
+    }
+
+    fn inject_fully_negotiated_outbound(
+        &mut self,
+        protocol: <Self::OutboundProtocol as OutboundUpgrade<NegotiatedSubstream>>::Output,
+        message: Self::OutboundOpenInfo,
+    ) {
+        self.substream = Some(SubstreamState::PendingSendWithResponse(protocol, message));
+    }
+
+    fn inject_event(&mut self, event: HandlerInEvent) {
+        self.send_queue.push(event);
+        self.keep_alive = KeepAlive::Yes;
+    }
+
+    fn inject_dial_upgrade_error(
+        &mut self,
+        _: Self::OutboundOpenInfo,
+        e: ConnectionHandlerUpgrErr<
+            <Self::OutboundProtocol as OutboundUpgrade<NegotiatedSubstream>>::Error,
+        >,
+    ) {
+    }
+
+    fn connection_keep_alive(&self) -> KeepAlive {
+        self.keep_alive
+    }
+
+    fn poll(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<ConnectionHandlerEvent<TorkProtocol, (Message, ResponseSender), Message, io::Error>>
+    {
+        if !self.send_queue.is_empty()
+            && self.substream.is_none()
+            && !self.outbound_substream_establishing
+        {
+            let message = self.send_queue.remove(0);
+            self.send_queue.shrink_to_fit();
+            self.outbound_substream_establishing = true;
+
+            if let HandlerInEvent::Request(msg, sender) = message {
+                return Poll::Ready(ConnectionHandlerEvent::OutboundSubstreamRequest {
+                    protocol: self.listen_protocol.clone().map_info(|()| (msg, sender)),
+                });
+            } else {
+                self.send_queue.push(message);
+            }
+        }
+        // read messages from inbound substream first
+        loop {
+            match std::mem::replace(&mut self.substream, Some(SubstreamState::Poisoned)) {
+                Some(SubstreamState::WaitingInput(mut substream)) => {
+                    match substream.poll_next_unpin(cx) {
+                        Poll::Ready(Some(Ok(message))) => {
+                            // reset keep alive idle timeout
+                            self.keep_alive = KeepAlive::Until(Instant::now() + self.idle_timeout);
+
+                            // we've received an inbound, now we'll wait to send a message on that
+                            // stream.
+                            self.substream = Some(SubstreamState::WaitingOutput(substream));
+                            return Poll::Ready(ConnectionHandlerEvent::Custom(message));
+                        }
+                        Poll::Ready(Some(Err(error))) => {
+                            // More serious errors, close this side of the stream. If the
+                            // peer is still around, they will re-establish their connection
+                            self.substream = Some(SubstreamState::Closing(substream));
+                        }
+                        // peer closed the stream
+                        Poll::Ready(None) => {
+                            self.substream = Some(SubstreamState::Closing(substream));
+                        }
+                        Poll::Pending => {
+                            self.substream = Some(SubstreamState::WaitingInput(substream));
+                            break;
+                        }
+                    }
+                }
+                Some(SubstreamState::WaitingOutput(substream)) => {
+                    if !self.send_queue.is_empty() {
+                        let message = self.send_queue.remove(0);
+                        self.send_queue.shrink_to_fit();
+
+                        match message {
+                            HandlerInEvent::Response(message) => {
+                                self.substream =
+                                    Some(SubstreamState::PendingSend(substream, message));
+                            }
+                            HandlerInEvent::Request(message, sender) => {
+                                self.substream = Some(SubstreamState::PendingSendWithResponse(
+                                    substream,
+                                    (message, sender),
+                                ));
+                            }
+                        };
+                    } else {
+                        self.substream = Some(SubstreamState::WaitingOutput(substream));
+                        break;
+                    }
+                }
+                Some(SubstreamState::PendingSend(mut substream, message)) => {
+                    match Sink::poll_ready(Pin::new(&mut substream), cx) {
+                        Poll::Ready(Ok(())) => {
+                            match Sink::start_send(Pin::new(&mut substream), message) {
+                                Ok(()) => {
+                                    self.substream = Some(SubstreamState::PendingFlush(substream))
+                                }
+                                Err(e) => {
+                                    return Poll::Ready(ConnectionHandlerEvent::Close(e));
+                                }
+                            }
+                        }
+                        Poll::Ready(Err(e)) => {
+                            return Poll::Ready(ConnectionHandlerEvent::Close(e));
+                        }
+                        Poll::Pending => {
+                            self.keep_alive = KeepAlive::Yes;
+                            self.substream = Some(SubstreamState::PendingSend(substream, message));
+                            break;
+                        }
+                    }
+                }
+                Some(SubstreamState::PendingSendWithResponse(mut substream, (message, sender))) => {
+                    match Sink::poll_ready(Pin::new(&mut substream), cx) {
+                        Poll::Ready(Ok(())) => {
+                            match Sink::start_send(Pin::new(&mut substream), message) {
+                                Ok(()) => {
+                                    self.substream = Some(SubstreamState::PendingFlushWithResponse(
+                                        substream, sender,
+                                    ))
+                                }
+                                Err(e) => {
+                                    return Poll::Ready(ConnectionHandlerEvent::Close(e));
+                                }
+                            }
+                        }
+                        Poll::Ready(Err(e)) => {
+                            return Poll::Ready(ConnectionHandlerEvent::Close(e));
+                        }
+                        Poll::Pending => {
+                            self.keep_alive = KeepAlive::Yes;
+                            self.substream = Some(SubstreamState::PendingSendWithResponse(
+                                substream,
+                                (message, sender),
+                            ));
+                            break;
+                        }
+                    }
+                }
+                Some(SubstreamState::PendingFlush(mut substream)) => {
+                    match Sink::poll_flush(Pin::new(&mut substream), cx) {
+                        Poll::Ready(Ok(())) => {
+                            // reset the idle timeout
+                            self.keep_alive = KeepAlive::Until(Instant::now() + self.idle_timeout);
+
+                            self.substream = Some(SubstreamState::WaitingInput(substream))
+                        }
+                        Poll::Ready(Err(e)) => {
+                            return Poll::Ready(ConnectionHandlerEvent::Close(e))
+                        }
+                        Poll::Pending => {
+                            self.keep_alive = KeepAlive::Yes;
+                            self.substream = Some(SubstreamState::PendingFlush(substream));
+                            break;
+                        }
+                    }
+                }
+                Some(SubstreamState::PendingFlushWithResponse(mut substream, sender)) => {
+                    match Sink::poll_flush(Pin::new(&mut substream), cx) {
+                        Poll::Ready(Ok(())) => {
+                            // reset the idle timeout
+                            self.keep_alive = KeepAlive::Until(Instant::now() + self.idle_timeout);
+
+                            self.substream =
+                                Some(SubstreamState::PendingResponse(substream, sender))
+                        }
+                        Poll::Ready(Err(e)) => {
+                            return Poll::Ready(ConnectionHandlerEvent::Close(e))
+                        }
+                        Poll::Pending => {
+                            self.keep_alive = KeepAlive::Yes;
+                            self.substream =
+                                Some(SubstreamState::PendingFlushWithResponse(substream, sender));
+                            break;
+                        }
+                    }
+                }
+                Some(SubstreamState::PendingResponse(mut substream, sender)) => {
+                    match substream.poll_next_unpin(cx) {
+                        Poll::Ready(Some(Ok(message))) => {
+                            sender.send(Ok(message)).ok();
+                            // reset keep alive idle timeout
+                            self.keep_alive = KeepAlive::Until(Instant::now() + self.idle_timeout);
+
+                            self.substream = Some(SubstreamState::WaitingOutput(substream));
+                            break;
+                        }
+                        Poll::Ready(Some(Err(error))) => {
+                            return Poll::Ready(ConnectionHandlerEvent::Close(error));
+                        }
+                        // peer closed the stream
+                        Poll::Ready(None) => {
+                            // self.inbound_substream =
+                            // Some(InboundSubstreamState::Closing(substream));
+                            break;
+                        }
+                        Poll::Pending => {
+                            self.substream =
+                                Some(SubstreamState::PendingResponse(substream, sender));
+                            break;
+                        }
+                    }
+                }
+                Some(SubstreamState::Closing(mut substream)) => {
+                    match Sink::poll_close(Pin::new(&mut substream), cx) {
+                        Poll::Ready(res) => {
+                            if let Err(e) = res {
+                                // Don't close the connection but just drop the inbound substream.
+                                // In case the remote has more to send, they will open up a new
+                                // substream.
+                            }
+                            self.substream = None;
+                            self.keep_alive = KeepAlive::No;
+                            break;
+                        }
+                        Poll::Pending => {
+                            self.substream = Some(SubstreamState::Closing(substream));
+                            break;
+                        }
+                    }
+                }
+                None => {
+                    self.substream = None;
+                    break;
+                }
+                Some(SubstreamState::Poisoned) => {
+                    unreachable!("Error occurred during inbound stream processing")
+                }
+            }
+        }
+
+        Poll::Pending
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use libipld::ipld;
+    use libp2p::swarm::{Swarm, SwarmEvent};
+    use tokio::sync::mpsc;
+    use tracing::{info, trace, Level};
+    use tracing_subscriber::{filter::LevelFilter, fmt, prelude::*};
+
+    use super::*;
+
+    // Get content for a given number of blocks and providers
+    async fn get_content<const NB: usize, const NP: usize>() {
+        let blocks = (1..NB)
+            .map(|_| create_random_block::<64>())
+            .collect::<Vec<_>>();
+
+        let mut links: Vec<Ipld> = Vec::new();
+        for (cid, bytes, _) in &blocks {
+            links.push(ipld!({
+                "Hash": cid,
+                "Tsize": bytes.len(),
+            }));
+        }
+
+        let root_node = ipld!({
+            "Links": links,
+        });
+
+        let buf = encode_ipld(CBOR, &root_node);
+        let (root, bytes, _) = create_block(buf, CBOR);
+
+        let blocks = {
+            let mut rt_block = vec![(root, bytes, root_node)];
+            rt_block.extend(blocks);
+            rt_block
+        };
+
+        let mut providers = Vec::new();
+        let (tx, mut rx) = mpsc::channel::<Multiaddr>(1);
+
+        for _ in 0..NP {
+            let (peer_id, trans) = mk_transport();
+            let store = TestStore::default();
+            let t = Tork::new(peer_id, store.clone());
+            let mut swarm = Swarm::with_tokio_executor(trans, t, peer_id);
+
+            for (cid, bytes, _) in &blocks {
+                store.put(*cid, bytes.clone(), vec![]).unwrap();
+            }
+
+            Swarm::listen_on(&mut swarm, "/ip4/127.0.0.1/tcp/0".parse().unwrap()).unwrap();
+
+            let sender = tx.clone();
+            providers.push(tokio::task::spawn(async move {
+                while swarm.next().now_or_never().is_some() {}
+                let listeners: Vec<_> = Swarm::listeners(&swarm).collect();
+                for l in listeners {
+                    sender.send(l.clone()).await.unwrap();
+                }
+
+                loop {
+                    let ev = swarm.next().await;
+                    trace!("peer1: {:?}", ev);
+                }
+            }));
+        }
+
+        let (peer2_id, trans) = mk_transport();
+        let store2 = TestStore::default();
+
+        let t2 = Tork::new(peer2_id, store2.clone());
+        let mut swarm2 = Swarm::with_tokio_executor(trans, t2, peer2_id);
+
+        let swarm2_tk = swarm2.behaviour().clone();
+
+        for i in 0..NP {
+            let addr = rx.recv().await.unwrap();
+            info!("client: dialing peer{} at {}", i, addr);
+            Swarm::dial(&mut swarm2, addr).unwrap();
+        }
+
+        let mut conns = 0;
+
+        loop {
+            match swarm2.next().await {
+                Some(SwarmEvent::ConnectionEstablished { peer_id, .. }) => {
+                    trace!("client: connected to {}", peer_id);
+                    conns += 1;
+
+                    if conns == NP {
+                        break;
+                    }
+                }
+                _ => (),
+            }
+        }
+
+        let client = tokio::task::spawn(async move {
+            loop {
+                let ev = swarm2.next().await;
+                trace!("peer2: {:?}", ev);
+            }
+        });
+
+        let session = swarm2_tk.new_session().unwrap();
+        let content = session.resolve_all(root).await;
+
+        let results = content.try_collect::<Vec<Ipld>>().await.unwrap();
+
+        assert_eq!(results.len(), NB);
+
+        for (cid, bytes, _) in blocks.into_iter() {
+            let stored = store2.get(&cid).unwrap();
+            assert_eq!(bytes, stored);
+        }
+
+        for provider in providers {
+            provider.abort();
+            provider.await.ok();
+        }
+
+        client.abort();
+        client.await.ok();
+    }
+
+    #[tokio::test]
+    async fn test_get_1_block_1_provider() {
+        get_content::<1, 1>().await;
+    }
+
+    #[tokio::test]
+    async fn test_get_4_blocks_1_provider() {
+        get_content::<4, 1>().await;
+    }
+
+    #[tokio::test]
+    async fn test_get_4_blocks_2_providers() {
+        // tracing_subscriber::registry()
+        //     .with(fmt::layer().pretty())
+        //     .with(LevelFilter::from_level(Level::DEBUG))
+        //     .init();
+
+        get_content::<4, 2>().await;
+    }
+
+    #[tokio::test]
+    async fn test_get_64_blocks_4_providers() {
+        get_content::<64, 4>().await;
+    }
+
+    #[tokio::test]
+    async fn test_get_128_blocks_4_providers() {
+        get_content::<128, 4>().await;
+    }
+
+    #[tokio::test]
+    async fn test_get_600_blocks_4_providers() {
+        get_content::<600, 4>().await;
+    }
+}

--- a/tork/src/prefix.rs
+++ b/tork/src/prefix.rs
@@ -1,0 +1,75 @@
+use anyhow::Result;
+use libipld::cid::multihash::{Code, Multihash, MultihashDigest};
+use libipld::cid::{Cid, Version};
+use unsigned_varint::{decode as varint_decode, encode as varint_encode};
+
+#[derive(PartialEq, Eq, Clone, Debug, Copy)]
+pub struct Prefix {
+    pub version: Version,
+    pub codec: u64,
+    pub mh_type: u64,
+    pub mh_len: usize,
+}
+
+impl Prefix {
+    // default to cid v1 with default hash length
+    pub fn new(codec: u64, mh_type: u64) -> Self {
+        Prefix {
+            version: Version::V1,
+            codec,
+            mh_type,
+            mh_len: 0,
+        }
+    }
+
+    pub fn new_from_bytes(data: &[u8]) -> Result<Prefix> {
+        let (raw_version, remain) = varint_decode::u64(data)?;
+        let version = Version::try_from(raw_version)?;
+        let (codec, remain) = varint_decode::u64(remain)?;
+        let (mh_type, remain) = varint_decode::u64(remain)?;
+        let (mh_len, _remain) = varint_decode::usize(remain)?;
+
+        Ok(Prefix {
+            version,
+            codec,
+            mh_type,
+            mh_len,
+        })
+    }
+
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut res = Vec::with_capacity(4);
+
+        let mut buf = varint_encode::u64_buffer();
+        let version = varint_encode::u64(self.version.into(), &mut buf);
+        res.extend_from_slice(version);
+        let mut buf = varint_encode::u64_buffer();
+        let codec = varint_encode::u64(self.codec, &mut buf);
+        res.extend_from_slice(codec);
+        let mut buf = varint_encode::u64_buffer();
+        let mh_type = varint_encode::u64(self.mh_type.into(), &mut buf);
+        res.extend_from_slice(mh_type);
+        let mut buf = varint_encode::u64_buffer();
+        let mh_len = varint_encode::u64(self.mh_len as u64, &mut buf);
+        res.extend_from_slice(mh_len);
+
+        res
+    }
+
+    pub fn to_cid(&self, data: &[u8]) -> Result<Cid> {
+        let hash: Multihash = Code::try_from(self.mh_type)?.digest(data);
+        let cid = Cid::new(self.version, self.codec, hash)?;
+        Ok(cid)
+    }
+}
+
+impl From<&Cid> for Prefix {
+    fn from(cid: &Cid) -> Self {
+        Self {
+            version: cid.version(),
+            codec: cid.codec(),
+            mh_type: cid.hash().code(),
+            mh_len: cid.hash().size().into(),
+        }
+    }
+}

--- a/tork/src/protocol.rs
+++ b/tork/src/protocol.rs
@@ -1,0 +1,350 @@
+use crate::prefix::Prefix;
+use anyhow::Result;
+use asynchronous_codec::{Decoder, Encoder, Framed};
+use bytes::{Bytes, BytesMut};
+use futures::future::{self, BoxFuture};
+use futures::io::{AsyncRead, AsyncWrite};
+use libipld::Cid;
+use libp2p::core::{InboundUpgrade, OutboundUpgrade, UpgradeInfo};
+use serde::{Deserialize, Serialize};
+use serde_ipld_dagcbor::{from_slice, to_vec};
+use serde_repr::*;
+use serde_tuple::*;
+use std::{io, iter};
+use unsigned_varint::codec;
+
+pub trait Store: std::fmt::Debug + Clone + Send + Sync + 'static {
+    fn get(&self, cid: &Cid) -> Result<Bytes>;
+    fn put<T: AsRef<[u8]>, L: IntoIterator<Item = Cid>>(
+        &self,
+        cid: Cid,
+        bytes: T,
+        links: L,
+    ) -> Result<()>;
+}
+
+const MAX_BUF_SIZE: usize = 1024 * 1024 * 2;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Request {
+    pub root: Cid,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
+pub struct Block {
+    pub prefix: Bytes,
+    pub data: Bytes,
+}
+
+impl Block {
+    pub fn new(cid: Cid, data: Bytes) -> Self {
+        let prefix = Bytes::from(Prefix::from(&cid).to_bytes());
+        Block { prefix, data }
+    }
+}
+
+#[derive(PartialEq, Clone, Copy, Eq, Debug, Serialize_repr, Deserialize_repr)]
+#[repr(i32)]
+pub enum StatusCode {
+    Partial = 14,
+    Completed = 20,
+    NotFound = 34,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Response {
+    pub status: StatusCode,
+    pub blocks: Vec<Block>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Message {
+    #[serde(rename = "req", skip_serializing_if = "Option::is_none")]
+    pub request: Option<Request>,
+    #[serde(rename = "resp", skip_serializing_if = "Option::is_none")]
+    pub response: Option<Response>,
+}
+
+impl Message {
+    pub fn complete_response(blocks: Vec<Block>) -> Self {
+        Message {
+            request: None,
+            response: Some(Response {
+                status: StatusCode::Completed,
+                blocks,
+            }),
+        }
+    }
+}
+
+impl From<Request> for Message {
+    fn from(req: Request) -> Message {
+        Message {
+            request: Some(req),
+            response: None,
+        }
+    }
+}
+
+impl From<Cid> for Message {
+    fn from(cid: Cid) -> Message {
+        Message {
+            request: Some(Request { root: cid }),
+            response: None,
+        }
+    }
+}
+
+pub struct TorkCodec {
+    /// Codec to encode/decode the Unsigned varint length prefix of the frames.
+    pub length_codec: codec::UviBytes,
+}
+
+impl TorkCodec {
+    pub fn new(length_codec: codec::UviBytes) -> Self {
+        TorkCodec { length_codec }
+    }
+}
+
+impl Encoder for TorkCodec {
+    type Item = Message;
+    type Error = io::Error;
+
+    fn encode(&mut self, item: Self::Item, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        let buf = to_vec(&item).map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+
+        // length prefix the protobuf message, ensuring the max limit is not hit
+        self.length_codec
+            .encode(Bytes::from(buf), dst)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))
+    }
+}
+
+impl Decoder for TorkCodec {
+    type Item = Message;
+    type Error = io::Error;
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        let packet = match self.length_codec.decode(src)? {
+            Some(p) => p,
+            None => return Ok(None),
+        };
+
+        let message: Message = from_slice(&packet.freeze())
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+
+        Ok(Some(message))
+    }
+}
+
+pub const PROTOCOL_NAME: &[u8; 16] = b"/ipfs/tork/0.1.0";
+
+#[derive(Debug, Clone)]
+pub struct TorkProtocol();
+
+impl UpgradeInfo for TorkProtocol {
+    type Info = &'static [u8];
+    type InfoIter = iter::Once<Self::Info>;
+
+    fn protocol_info(&self) -> Self::InfoIter {
+        iter::once(PROTOCOL_NAME)
+    }
+}
+
+impl<C> InboundUpgrade<C> for TorkProtocol
+where
+    C: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
+    type Output = Framed<C, TorkCodec>;
+    type Error = io::Error;
+    type Future = BoxFuture<'static, Result<Self::Output, Self::Error>>;
+
+    fn upgrade_inbound(self, socket: C, _: Self::Info) -> Self::Future {
+        let mut length_codec = codec::UviBytes::default();
+        length_codec.set_max_len(MAX_BUF_SIZE);
+        Box::pin(future::ok(Framed::new(
+            socket,
+            TorkCodec::new(length_codec),
+        )))
+    }
+}
+
+impl<C> OutboundUpgrade<C> for TorkProtocol
+where
+    C: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
+    type Output = Framed<C, TorkCodec>;
+    type Error = io::Error;
+    type Future = BoxFuture<'static, Result<Self::Output, Self::Error>>;
+
+    fn upgrade_outbound(self, socket: C, _: Self::Info) -> Self::Future {
+        let mut length_codec = codec::UviBytes::default();
+        length_codec.set_max_len(MAX_BUF_SIZE);
+        Box::pin(future::ok(Framed::new(
+            socket,
+            TorkCodec::new(length_codec),
+        )))
+    }
+}
+
+pub mod tests {
+    use super::*;
+    use futures::channel::oneshot;
+    use futures::prelude::*;
+    use libipld::cid::multihash::{Code, MultihashDigest};
+    use libipld::codec_impl::IpldCodec;
+    use libipld::{codec::Encode, Ipld};
+    use libp2p::core::muxing::StreamMuxerBox;
+    use libp2p::core::transport::Boxed;
+    use libp2p::core::upgrade::{apply_inbound, apply_outbound, Version};
+    use libp2p::identity::Keypair;
+    use libp2p::{noise, tcp, yamux, PeerId, Transport};
+    use rand::prelude::*;
+    use std::{
+        collections::HashMap,
+        io::{Error, ErrorKind},
+        sync::Arc,
+        time::Duration,
+    };
+    use tokio::sync::RwLock;
+
+    pub const RAW: u64 = 0x55;
+    pub const CBOR: u64 = 0x71;
+
+    pub fn create_random_block<const S: usize>() -> (Cid, Bytes, Ipld) {
+        let mut bytes = BytesMut::with_capacity(S);
+        bytes.resize(S, 0);
+        thread_rng().fill(&mut bytes[..]);
+        create_block(bytes, RAW)
+    }
+
+    pub fn create_block<B: Into<Bytes>>(bytes: B, codec: u64) -> (Cid, Bytes, Ipld) {
+        let bytes = bytes.into();
+        let digest = Code::Sha2_256.digest(&bytes);
+        let cid = Cid::new_v1(codec, digest);
+        (cid, bytes.clone(), Ipld::Bytes(bytes.into()))
+    }
+
+    pub fn encode_ipld(codec: u64, n: &Ipld) -> impl Into<Bytes> {
+        let codec = IpldCodec::try_from(codec).unwrap();
+        let mut buf = Vec::new();
+        Ipld::encode(n, codec, &mut buf).unwrap();
+        buf
+    }
+
+    #[derive(Debug, Clone, Default)]
+    pub struct TestStore {
+        store: Arc<RwLock<HashMap<Cid, Bytes>>>,
+    }
+
+    impl Store for TestStore {
+        fn get(&self, cid: &Cid) -> Result<Bytes> {
+            self.store
+                .try_read()?
+                .get(cid)
+                .cloned()
+                .ok_or_else(|| anyhow::format_err!("missing"))
+        }
+
+        fn put<T: AsRef<[u8]>, L: IntoIterator<Item = Cid>>(
+            &self,
+            cid: Cid,
+            bytes: T,
+            _links: L,
+        ) -> Result<()> {
+            self.store
+                .try_write()?
+                .insert(cid, bytes.as_ref().to_vec().into());
+            Ok(())
+        }
+    }
+
+    pub fn mk_transport() -> (PeerId, Boxed<(PeerId, StreamMuxerBox)>) {
+        let local_key = Keypair::generate_ed25519();
+
+        let auth_config = {
+            let dh_keys = noise::Keypair::<noise::X25519Spec>::new()
+                .into_authentic(&local_key)
+                .expect("Noise key generation failed");
+
+            noise::NoiseConfig::xx(dh_keys).into_authenticated()
+        };
+
+        let peer_id = local_key.public().to_peer_id();
+        let transport = tcp::tokio::Transport::new(tcp::Config::default().nodelay(true))
+            .upgrade(Version::V1)
+            .authenticate(auth_config)
+            .multiplex(yamux::YamuxConfig::default())
+            .timeout(Duration::from_secs(20))
+            .map(|(peer_id, muxer), _| (peer_id, StreamMuxerBox::new(muxer)))
+            .map_err(|err| Error::new(ErrorKind::Other, err))
+            .boxed();
+        (peer_id, transport)
+    }
+
+    #[tokio::test]
+    async fn test_protocol() {
+        let (tx, rx) = oneshot::channel();
+
+        let cid: Cid = "bafyreifjthbkzdxj2baze2d2xqs2f73jcu7asubv42elz2vvuw6fdqv4py"
+            .parse()
+            .unwrap();
+
+        let bg_task = tokio::task::spawn(async move {
+            let mut transport =
+                tcp::tokio::Transport::new(tcp::Config::default().nodelay(true)).boxed();
+
+            transport
+                .listen_on("/ip4/127.0.0.1/tcp/0".parse().unwrap())
+                .unwrap();
+
+            let addr = transport
+                .next()
+                .await
+                .expect("new address event")
+                .into_new_address()
+                .expect("listen address");
+
+            tx.send(addr).unwrap();
+
+            let socket = transport
+                .next()
+                .await
+                .expect("request event")
+                .into_incoming()
+                .unwrap()
+                .0
+                .await
+                .unwrap();
+
+            let msg = apply_inbound(socket, TorkProtocol())
+                .await
+                .unwrap()
+                .next()
+                .await
+                .unwrap()
+                .unwrap();
+
+            assert_eq!(msg.request.expect("to be request").root, cid);
+        });
+        let client = tokio::task::spawn(async move {
+            let mut transport =
+                tcp::tokio::Transport::new(tcp::Config::default().nodelay(true)).boxed();
+
+            let socket = transport.dial(rx.await.unwrap()).unwrap().await.unwrap();
+
+            let mut framed = apply_outbound(socket, TorkProtocol(), Version::V1)
+                .await
+                .unwrap();
+
+            let msg: Message = Request { root: cid }.into();
+
+            framed.send(msg).await.unwrap();
+            framed.flush().await.unwrap();
+
+            bg_task.await.unwrap();
+        });
+
+        client.await.unwrap();
+    }
+}

--- a/tork/src/protocol.rs
+++ b/tork/src/protocol.rs
@@ -75,6 +75,16 @@ impl Message {
             }),
         }
     }
+
+    pub fn not_found() -> Self {
+        Message {
+            request: None,
+            response: Some(Response {
+                status: StatusCode::NotFound,
+                blocks: vec![],
+            }),
+        }
+    }
 }
 
 impl From<Request> for Message {

--- a/tork/src/session.rs
+++ b/tork/src/session.rs
@@ -160,7 +160,7 @@ mod tests {
     };
     use libipld::ipld;
     use std::collections::HashMap;
-    use tracing::{info, trace, Level};
+    use tracing::info;
     // use tracing_subscriber::{filter::LevelFilter, fmt, prelude::*};
 
     fn assert_send<T: Send>() {}

--- a/tork/src/session.rs
+++ b/tork/src/session.rs
@@ -1,0 +1,254 @@
+use crate::prefix::Prefix;
+use crate::protocol::{Message, StatusCode, Store};
+use anyhow::Result;
+use async_stream::try_stream;
+use futures::{prelude::*, stream::FuturesUnordered};
+use libipld::codec::Codec;
+use libipld::codec_impl::IpldCodec;
+use libipld::{Cid, Ipld};
+use libp2p::{core::connection::ConnectionId, PeerId};
+use std::{collections::BTreeSet, sync::Arc};
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+use tracing::{info, warn};
+
+pub type BlockSender = oneshot::Sender<Result<(Ipld, Vec<Cid>)>>;
+pub type ResponseSender = oneshot::Sender<Result<Message>>;
+pub type NetworkSender = async_channel::Sender<NetEvent>;
+
+#[derive(Debug)]
+pub enum NetEvent {
+    SendMessage {
+        peer: PeerId,
+        message: Message,
+        connection_id: ConnectionId,
+    },
+    SendRequest {
+        peer: PeerId,
+        message: Message,
+        connection_id: ConnectionId,
+        response: ResponseSender,
+    },
+}
+
+pub struct Task {
+    cid: Cid,
+    result: BlockSender,
+}
+
+#[derive(Debug)]
+pub struct Session<S: Store> {
+    store: S,
+    // links: deque::Worker<Task>,
+    links: async_channel::Sender<Task>,
+    workers: Arc<Vec<JoinHandle<()>>>,
+}
+
+impl<S: Store> Session<S> {
+    pub fn new<'a, P>(store: S, net: NetworkSender, providers: P) -> Self
+    where
+        P: Iterator<Item = (&'a PeerId, &'a ConnectionId)>,
+    {
+        let (wx, sx) = async_channel::bounded(128);
+        // let (w, s) = deque::new::<Task>();
+        let mut workers = Vec::new();
+        for (p, c) in providers {
+            let network_sender = net.clone();
+            let peer = *p;
+            let conn_id = *c;
+            let mut stealer: async_channel::Receiver<Task> = sx.clone(); // s.clone();
+            let store = store.clone();
+
+            // TODO: workers should keep track of peer connectivity, stats etc.
+            workers.push(tokio::task::spawn(async move {
+                while let Some(task) = stealer.next().await {
+                    let (s, r) = oneshot::channel();
+                    let _ = network_sender
+                        .send(NetEvent::SendRequest {
+                            peer,
+                            message: task.cid.into(),
+                            connection_id: conn_id,
+                            response: s,
+                        })
+                        .await;
+
+                    match r.await {
+                        Ok(Ok(res)) => {
+                            let result = res
+                                .response
+                                .as_ref()
+                                .ok_or_else(|| anyhow::format_err!("not a response message"))
+                                .and_then(|res| {
+                                    if let Some(blk) = res.blocks.iter().next() {
+                                        return Ok(blk);
+                                    }
+                                    if let StatusCode::NotFound = res.status {
+                                        return Err(anyhow::format_err!("block not found"));
+                                    }
+                                    Err(anyhow::format_err!("empty message"))
+                                })
+                                .and_then(|blk| {
+                                    let cid =
+                                        Prefix::new_from_bytes(&blk.prefix)?.to_cid(&blk.data)?;
+                                    let codec = IpldCodec::try_from(cid.codec())?;
+                                    let node: Ipld = codec.decode(&blk.data)?;
+
+                                    let mut linkset = BTreeSet::new();
+                                    node.references(&mut linkset);
+                                    let links = linkset.into_iter().collect::<Vec<Cid>>();
+
+                                    store.put(cid, &blk.data, links.clone())?;
+                                    Ok((node, links))
+                                });
+                            if let Err(err) = task.result.send(result) {
+                                warn!("task result sender: {:?}", err);
+                            }
+                        }
+                        Ok(Err(other)) => {
+                            warn!("send:{}: failed: {:?}", peer, other);
+                        }
+                        _ => {}
+                    };
+                }
+            }));
+        }
+        Session {
+            store,
+            links: wx,
+            workers: Arc::new(workers),
+        }
+    }
+
+    pub async fn resolve_all(&self, root: Cid) -> impl Stream<Item = Result<Ipld>> + '_ {
+        let mut jobs = FuturesUnordered::new();
+        jobs.push(self.load_link(root));
+
+        try_stream! {
+
+            while let Some(Ok((node, links))) = jobs.next().await {
+
+                for l in links.into_iter() {
+                    jobs.push(self.load_link(l));
+                }
+
+                yield node;
+            }
+        }
+    }
+
+    pub async fn load_link(&self, cid: Cid) -> Result<(Ipld, Vec<Cid>)> {
+        let (s, r) = oneshot::channel();
+        self.links.send(Task { cid, result: s }).await?;
+        match r.await {
+            Ok(res) => res,
+            _ => Err(anyhow::format_err!("sender was dropped")),
+        }
+    }
+
+    pub fn stop(self) {
+        for handle in self.workers.iter() {
+            handle.abort();
+        }
+    }
+}
+
+mod tests {
+    use super::*;
+    use crate::protocol::{
+        tests::{create_block, create_random_block, encode_ipld, TestStore, CBOR},
+        Block,
+    };
+    use libipld::ipld;
+    use std::collections::HashMap;
+    use tracing::{info, trace, Level};
+    // use tracing_subscriber::{filter::LevelFilter, fmt, prelude::*};
+
+    fn assert_send<T: Send>() {}
+
+    #[test]
+    fn test_traits() {
+        assert_send::<Session<TestStore>>();
+        assert_send::<&Session<TestStore>>();
+    }
+
+    async fn get_content() {
+        let blocks = (0..16)
+            .map(|_| create_random_block::<1024>())
+            .collect::<Vec<_>>();
+
+        let mut links: Vec<Ipld> = Vec::new();
+        for (cid, bytes, _) in &blocks {
+            links.push(ipld!({
+                "Hash": cid,
+                "Tsize": bytes.len(),
+            }));
+        }
+
+        let root_node = ipld!({
+            "Links": links,
+        });
+
+        let buf = encode_ipld(CBOR, &root_node);
+        let (root, bytes, _) = create_block(buf, CBOR);
+
+        let blocks = {
+            let mut rt_block = vec![(root, bytes, root_node)];
+            rt_block.extend(blocks);
+            rt_block
+        };
+
+        let store = TestStore::default();
+
+        for (cid, bytes, _) in &blocks {
+            store.put(*cid, bytes.clone(), vec![]).unwrap();
+        }
+
+        let (network_sender, mut network_receiver) = async_channel::bounded(1024);
+
+        tokio::task::spawn(async move {
+            while let Some(NetEvent::SendRequest {
+                message,
+                response,
+                connection_id,
+                ..
+            }) = network_receiver.next().await
+            {
+                tokio::task::spawn({
+                    let store = store.clone();
+                    let req = message.request.unwrap();
+                    async move {
+                        info!("conn {:?} handling request", connection_id);
+                        if let Ok(bytes) = store.get(&req.root) {
+                            let blk = Block::new(req.root, bytes);
+                            let msg = Message::complete_response(vec![blk]);
+                            response.send(Ok(msg)).ok();
+                        }
+                    }
+                });
+            }
+        });
+
+        let providers: HashMap<PeerId, ConnectionId> = HashMap::from([
+            (PeerId::random(), ConnectionId::new(1)),
+            (PeerId::random(), ConnectionId::new(2)),
+            (PeerId::random(), ConnectionId::new(3)),
+            (PeerId::random(), ConnectionId::new(4)),
+        ]);
+        let session = Session::new(TestStore::default(), network_sender, providers.iter());
+
+        let content = session.resolve_all(root).await;
+
+        let results = content.try_collect::<Vec<Ipld>>().await.unwrap();
+        assert_eq!(results.len(), blocks.len());
+    }
+
+    #[tokio::test]
+    async fn test_session() {
+        // tracing_subscriber::registry()
+        //     .with(fmt::layer().pretty())
+        //     .with(LevelFilter::from_level(Level::DEBUG))
+        //     .init();
+
+        get_content().await;
+    }
+}


### PR DESCRIPTION
This is a rebased version of @tchardin's #10, allowing for quicker toggling between bitswap and tork during tests this morning/week. 

This also adds a protocol flag to toggle between transfer protocols. 

